### PR TITLE
improve xmake.lua

### DIFF
--- a/demo/xmake.lua
+++ b/demo/xmake.lua
@@ -1,44 +1,22 @@
--- the debug mode
-if is_mode("debug") then
-    
-    -- enable the debug symbols
-    set_symbols("debug")
-
-    -- disable optimization
-    set_optimize("none")
-end
-
--- the release mode
-if is_mode("release") then
-
-    -- set the symbols visibility: hidden
-    set_symbols("hidden")
-
-    -- enable fastest optimization
-    set_optimize("fastest")
-
-    -- strip all symbols
-    set_strip("all")
-end
-
 target("demo")
     set_kind("binary")
+    set_default(false)
     set_targetdir("app/")
+    add_deps("LCUIEx")
     add_files("src/*.c")
     add_files("src/ui/views/*.c")
     add_files("src/ui/helpers/*.c")
     add_includedirs("include", "../include", "../../LCUI/include", "../vendor/include")
-    add_linkdirs("../vendor/lib", "../dist/lib")
-    add_links("LCUIEx", "LCUI")
+
     before_build(function (target)
-        if val("plat") == "windows" then
-            os.cp("../dist/lib/*.dll", "app/")
-        else
-            os.cp("../dist/lib/*.so", "app/")
-        end
-        os.cp("../dist/assets/*", "app/assets")
+        os.cp("dist/lib/" .. target.filename("*", "shared"), "app/")
+        os.trycp("dist/assets/*", "app/assets")
     end)
-    if not is_os("windows") then
-        add_rpathdirs(".", "/usr/local/lib")
+
+    if is_mode("release") then
+        set_symbols("hidden")
     end
 
+    if not is_os("windows") then
+        add_rpathdirs("/usr/local/lib")
+    end

--- a/xmake.lua
+++ b/xmake.lua
@@ -1,3 +1,9 @@
+-- lcui.css 
+set_project("lcui.css")
+
+-- xmake minver
+set_xmakever("2.1.6")
+
 -- the debug mode
 if is_mode("debug") then
     
@@ -25,9 +31,12 @@ target("LCUIEx")
     add_files("src/ui/*.c")
     add_files("src/ui/components/*.c")
     add_includedirs("include", "../LCUI/include", "vendor/include", "vendor/lib")
-    add_links("LCUI")
     if is_os("windows") then
         add_linkdirs("vendor/lib")
-    else
-        add_rpathdirs("/usr/local/lib")
     end
+    on_load(function (target)
+        import("lib.detect.find_package")
+        target:add(find_package("LCUI"))
+    end)
+
+includes("demo")


### PR DESCRIPTION
Some improvements:

1. Demo as sub-project target, you can always build them in the root directory without having to specify a directory.
2. Uses `add_deps("LCUIEx")` to simplify `add_links`, `add_linkdirs`, `add_rpathdirs`, ...

Only build LCUIEx by default:

```console
$ xmake
```

Build demo:

```console
$ xmake build demo
```

Build all (LCUIEx + demo)

```console
$ xmake -a
```

Build and run demo

```console
$ xmake r demo
```